### PR TITLE
Add/base58-to-hex

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ The `fsc_utils` dbt package is a centralized repository consisting of various db
 1. Navigate to the `create_udfs.sql` macro in your respective repo where you want to install the package.
 2. Add the following: 
 ```
-{% set name %}
+{% set name %} 
 {{- fsc_utils.create_udfs() -}}
 {% endset %}
 {% do run_query(sql) %}

--- a/macros/streamline/configs.yaml.sql
+++ b/macros/streamline/configs.yaml.sql
@@ -158,6 +158,17 @@
   sql: |
     {{ fsc_utils.create_udf_transform_logs() | indent(4) }}
 
+- name: {{ schema }}.udf_base58_to_hex
+  signature:
+    - [input, STRING]
+  return_type: TEXT
+  options: |
+    LANGUAGE PYTHON
+    RUNTIME_VERSION = '3.8'
+    HANDLER = 'transform_base58_to_hex'
+  sql: |
+    {{ fsc_utils.create_udf_base58_to_hex() | indent(4) }}
+
 - name: {{ schema }}.udf_hex_to_base58
   signature:
     - [input, STRING]

--- a/macros/streamline/functions.py.sql
+++ b/macros/streamline/functions.py.sql
@@ -198,8 +198,8 @@ def transform_base58_to_hex(input):
 
     hex_string = hex(num)[2:]
 
-    if len(hex_string) <= 64:
-        hex_string = hex_string.zfill(64)
+    if len(hex_string) % 2 != 0:
+        hex_string = '0' + hex_string
 
     return '0x' + hex_string
 

--- a/macros/streamline/functions.py.sql
+++ b/macros/streamline/functions.py.sql
@@ -179,6 +179,32 @@ def transform(events: dict):
 
 {% endmacro %}
 
+{% macro create_udf_base58_to_hex() %}
+
+def transform_base58_to_hex(input):
+    if input is None:
+        return 'Invalid input'
+
+    ALPHABET = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
+    base_count = len(ALPHABET)
+
+    num = 0
+    for char in input:
+        num *= base_count
+        if char in ALPHABET:
+            num += ALPHABET.index(char)
+        else:
+            return 'Invalid character in input'
+
+    hex_string = hex(num)[2:]
+
+    if len(hex_string) <= 64:
+        hex_string = hex_string.zfill(64)
+
+    return '0x' + hex_string
+
+{% endmacro %}
+
 {% macro create_udf_hex_to_base58() %}
 
 def transform_hex_to_base58(input):


### PR DESCRIPTION
1. Adds new udf for encoding base58 to hex
2. Requires new version tag v1.15.0
