### PR TITLE
Flatten udf - add index_vals arg

### DIFF
--- a/macros/streamline/configs.yaml.sql
+++ b/macros/streamline/configs.yaml.sql
@@ -211,7 +211,7 @@
   return_type: ARRAY
   options: |
     LANGUAGE PYTHON
-    RUNTIME_VERSION = '3.8'
+    RUNTIME_VERSION = '3.11'
     COMMENT = 'Detect overflowed responses larger than 16MB'
     PACKAGES = ('snowflake-snowpark-python', 'pandas')
     HANDLER = 'main'
@@ -225,18 +225,18 @@
     - [index_vals, ARRAY]
   return_type: |
     table(
+          index_vals ARRAY,
           block_number NUMBER,
           metadata OBJECT,
           seq NUMBER,
           key STRING,
           path STRING,
           index NUMBER,
-          value_ VARIANT,
-          index_vals ARRAY
+          value_ VARIANT
         )
   options: |
     LANGUAGE PYTHON
-    RUNTIME_VERSION = '3.8'
+    RUNTIME_VERSION = '3.11'
     COMMENT = 'Flatten rows from a JSON file with overflowed responses larger than 16MB'
     PACKAGES = ('snowflake-snowpark-python', 'pandas', 'simplejson', 'numpy')
     HANDLER = 'FlattenRows'

--- a/macros/streamline/configs.yaml.sql
+++ b/macros/streamline/configs.yaml.sql
@@ -224,7 +224,8 @@
     - [index_cols, ARRAY]
     - [index_vals, ARRAY]
   return_type: |
-    table(block_number NUMBER,
+    table(index_vals ARRAY,
+          block_number NUMBER,
           metadata OBJECT,
           seq NUMBER,
           key STRING,

--- a/macros/streamline/configs.yaml.sql
+++ b/macros/streamline/configs.yaml.sql
@@ -224,14 +224,16 @@
     - [index_cols, ARRAY]
     - [index_vals, ARRAY]
   return_type: |
-    table(index_vals ARRAY,
+    table(
           block_number NUMBER,
           metadata OBJECT,
           seq NUMBER,
           key STRING,
           path STRING,
           index NUMBER,
-          value_ VARIANT)
+          value_ VARIANT,
+          index_vals ARRAY
+        )
   options: |
     LANGUAGE PYTHON
     RUNTIME_VERSION = '3.8'

--- a/macros/streamline/functions.py.sql
+++ b/macros/streamline/functions.py.sql
@@ -499,12 +499,8 @@ class FlattenRows:
         overflow = cleansed["value_"].astype(str).apply(len) > VARCHAR_MAX
 
         cleansed.loc[overflow, ["value_"]] = None
-        logger.debug(f"index_cols: {index_cols}")
-        logger.debug(f"Before: {cleansed.columns.values.tolist()}")
         temp_index_cols = list(range(len(index_cols)))
-        logger.debug(f"temp_index_cols: {temp_index_cols}")
         cleansed = cleansed.reset_index(names=temp_index_cols, drop=False)
-        logger.debug(f"After: {cleansed.columns.values.tolist()}")
         cleansed["index_cols"] = cleansed[temp_index_cols].apply(list, axis=1)
         cleansed.drop(columns=temp_index_cols, inplace=True, errors="ignore")
         return list(cleansed[np.roll(cleansed.columns.values, 1).tolist()].itertuples(index=False, name=None))

--- a/macros/streamline/functions.py.sql
+++ b/macros/streamline/functions.py.sql
@@ -507,5 +507,5 @@ class FlattenRows:
         logger.debug(f"After: {cleansed.columns.values.tolist()}")
         cleansed["index_cols"] = cleansed[temp_index_cols].apply(list, axis=1)
         cleansed.drop(columns=temp_index_cols, inplace=True, errors="ignore")
-        return list(cleansed[np.roll(cleansed.columns.values, 1).tolist()].itertuples(index=False, name=None))g
+        return list(cleansed[np.roll(cleansed.columns.values, 1).tolist()].itertuples(index=False, name=None))
 {% endmacro %}

--- a/macros/streamline/functions.py.sql
+++ b/macros/streamline/functions.py.sql
@@ -497,6 +497,8 @@ class FlattenRows:
         overflow = cleansed["value_"].astype(str).apply(len) > VARCHAR_MAX
 
         cleansed.loc[overflow, ["value_"]] = None
-        return list(cleansed.itertuples(index=True, name=None))
+        cleansed.drop(columns=index_cols, inplace=True, errors='ignore')
+        cleansed.reset_index(inplace=True, allow_duplicates=False, names=index_cols)
+        return list(cleansed.itertuples(index=False, name=None))
 
 {% endmacro %}

--- a/macros/streamline/functions.py.sql
+++ b/macros/streamline/functions.py.sql
@@ -497,8 +497,7 @@ class FlattenRows:
         overflow = cleansed["value_"].astype(str).apply(len) > VARCHAR_MAX
 
         cleansed.loc[overflow, ["value_"]] = None
-        cleansed.drop(columns=index_cols, inplace=True, errors='ignore')
-        cleansed.reset_index(inplace=True, allow_duplicates=False, names=index_cols)
+        cleansed.loc[overflow, ["value_"]] = None
+        cleansed["index_cols"] = pd.Series(cleansed.index.values, index=cleansed.index.values).apply(list)
         return list(cleansed.itertuples(index=False, name=None))
-
 {% endmacro %}

--- a/macros/streamline/functions.py.sql
+++ b/macros/streamline/functions.py.sql
@@ -497,7 +497,6 @@ class FlattenRows:
         overflow = cleansed["value_"].astype(str).apply(len) > VARCHAR_MAX
 
         cleansed.loc[overflow, ["value_"]] = None
-        cleansed.loc[overflow, ["value_"]] = None
         cleansed["index_cols"] = pd.Series(cleansed.index.values, index=cleansed.index.values).apply(list)
         return list(cleansed.itertuples(index=False, name=None))
 {% endmacro %}


### PR DESCRIPTION
udtf_flatten_overflowed_responses:
 - add param: index_vals ARRAY

This udf needs to be more granular to allow fewer responses to be processed ast a time to avoid memory issues.