### PR TITLE
Upgrade LQ to v1.4

### DIFF
--- a/packages.yml
+++ b/packages.yml
@@ -4,4 +4,4 @@ packages:
   - package: dbt-labs/dbt_utils
     version: [">=1.0.0", "<1.1.0"]
   - git: https://github.com/FlipsideCrypto/livequery-models.git
-    revision: "v1.3.0"
+    revision: "v1.4.0"


### PR DESCRIPTION
- upgrades LiveQuery to v1.4.0, which includes Vault Support for GitHub Action Utils
- tagged as v1.23.0