### PR TITLE
pin lq-base to v1.0.0

### DIFF
--- a/packages.yml
+++ b/packages.yml
@@ -4,4 +4,4 @@ packages:
   - package: dbt-labs/dbt_utils
     version: [">=1.0.0", "<1.1.0"]
   - git: https://github.com/FlipsideCrypto/livequery-base.git
-    revision: "main"
+    revision: v1.0.0


### PR DESCRIPTION
- Pins `livequery-base` dbt package to `v1.0.0`