### PR TITLE
[STREAM-1156] Update livequery-base package to v1.0.1

### DIFF
--- a/packages.yml
+++ b/packages.yml
@@ -4,4 +4,4 @@ packages:
   - package: dbt-labs/dbt_utils
     version: [">=1.0.0", "<1.1.0"]
   - git: https://github.com/FlipsideCrypto/livequery-base.git
-    revision: v1.0.0
+    revision: v1.0.1


### PR DESCRIPTION
update livequery base version in package 

- the new package fixes the default value for `data` in udf_api to `NULL`