### PR TITLE
bump livequery-base to v2.1.0 with namespace scope macro invocation

### DIFF
--- a/packages.yml
+++ b/packages.yml
@@ -4,5 +4,5 @@ packages:
   - package: dbt-labs/dbt_utils
     version: [">=1.0.0", "<1.1.0"]
   - git: https://github.com/FlipsideCrypto/livequery-base.git
-    revision: "v1.1.0"
+    revision: "v2.1.0"
 


### PR DESCRIPTION
- Bumps `livequery-base` to `v2.1.0` to include `get_rendered_model()` macro and namespace scoped `ephemeral_deploy` macros invocations to use for `live table udtf` deployments