### PR TITLE
bump lq-base -> v2.1.1

### DIFF
--- a/packages.yml
+++ b/packages.yml
@@ -3,6 +3,6 @@ packages:
     version: [">=0.8.0", "<0.9.0"]
   - package: dbt-labs/dbt_utils
     version: [">=1.0.0", "<1.1.0"]
-  - git: https://github.com/FlipsideCrypto/livequery-base.git
-    revision: "v2.1.1"
+  - git: https://github.com/FlipsideCrypto/livequery-models.git
+    revision: "STREAM-1175/reinstate-deploy-core"
 

--- a/packages.yml
+++ b/packages.yml
@@ -4,5 +4,5 @@ packages:
   - package: dbt-labs/dbt_utils
     version: [">=1.0.0", "<1.1.0"]
   - git: https://github.com/FlipsideCrypto/livequery-base.git
-    revision: "v2.1.0"
+    revision: "v2.1.1"
 


### PR DESCRIPTION
- Bump `livequery-base` to `v2.1.1` with namespace scoped `construct_api_route` macro