### PR TITLE
Stream 1175/livequery models reinstated

### DIFF
--- a/packages.yml
+++ b/packages.yml
@@ -3,6 +3,6 @@ packages:
     version: [">=0.8.0", "<0.9.0"]
   - package: dbt-labs/dbt_utils
     version: [">=1.0.0", "<1.1.0"]
-  - git: https://github.com/FlipsideCrypto/livequery-base.git
-    revision: "v2.1.1"
+  - git: https://github.com/FlipsideCrypto/livequery-models.git
+    revision: "STREAM-1175/reinstate-deploy-core"
 

--- a/packages.yml
+++ b/packages.yml
@@ -4,5 +4,5 @@ packages:
   - package: dbt-labs/dbt_utils
     version: [">=1.0.0", "<1.1.0"]
   - git: https://github.com/FlipsideCrypto/livequery-models.git
-    revision: "STREAM-1175/reinstate-deploy-core"
+    revision: "v2.0.0"
 

--- a/packages.yml
+++ b/packages.yml
@@ -4,5 +4,5 @@ packages:
   - package: dbt-labs/dbt_utils
     version: [">=1.0.0", "<1.1.0"]
   - git: https://github.com/FlipsideCrypto/livequery-models.git
-    revision: "v2.0.0"
+    revision: "v1.7.0"
 

--- a/packages.yml
+++ b/packages.yml
@@ -4,5 +4,5 @@ packages:
   - package: dbt-labs/dbt_utils
     version: [">=1.0.0", "<1.1.0"]
   - git: https://github.com/FlipsideCrypto/livequery-base.git
-    revision: "v2.1.0"
+    revision: "v2.1.1"
 


### PR DESCRIPTION
- Updates `livequery-models` dependency to `v2.0.0` release.
  - `livequery-models` `v2.0.0` : 
    - re-instates `deploy/core` ephemeral models
    - fixes `generic test_udf` macro compatibale with `dbt > 1.7`
    - adds `get_rendered_model()` macro to be used by `Livetable` UDTF's 