### PR TITLE
bump livequery-models -> 1.9.0

### DIFF
--- a/packages.yml
+++ b/packages.yml
@@ -4,5 +4,5 @@ packages:
   - package: dbt-labs/dbt_utils
     version: [">=1.0.0", "<1.1.0"]
   - git: https://github.com/FlipsideCrypto/livequery-models.git
-    revision: "v1.8.0"
+    revision: "v1.9.0"
 


### PR DESCRIPTION
- Bumps `livequery-models` -> `v1.9.0` with `Python Runtime 3.10` for `utls/udfs`