### PR TITLE
fsc-utils/v1.41.2

### DIFF
--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,3 @@
 packages:
   - git: https://github.com/FlipsideCrypto/livequery-models.git
-    revision: "v1.10.2"
+    revision: "v1.11.1"


### PR DESCRIPTION
## Summary
- Bump livequery-models from v1.10.2 to v1.11.1
- Picks up safe fallback for non-standard dbt target names (e.g. `dev-test`, `dev-2xl`)

## Deployment Steps
```bash
# 1. livequery-models — merge PR #134, tag v1.11.1
git checkout main && git pull
git tag v1.11.1 && git push origin v1.11.1

# 2. fsc-utils — merge this PR, tag v1.41.2
git checkout main && git pull
git tag v1.41.2 && git push origin v1.41.2

# 3. fsc-evm — merge fsc-evm PR #504, tag v4.45.14
git checkout main && git pull
git tag v4.45.14 && git push origin v4.45.14

# 4. chain repos — bump fsc-evm to v4.45.14 in packages.yml
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)