### PR TITLE
fsc-utils/v1.42.1

### DIFF
--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,3 @@
 packages:
   - git: https://github.com/FlipsideCrypto/livequery-models.git
-    revision: v1.12.0 
+    revision: v1.12.1


### PR DESCRIPTION
## Summary
Bump livequery-models from `v1.12.0` to `v1.12.1` to pick up a single-line bug fix.

## Changes
- `packages.yml`: livequery-models `v1.12.0` → `v1.12.1`

## Context
livequery-models [PR #135](https://github.com/FlipsideCrypto/livequery-models/pull/135) fixes a regression from the dbt 1.11 upgrade where `this.identifier` now returns the full model name instead of the alias, causing `ephemeral_deploy_marketplace` to reference the wrong schema when creating UDFs. Only 2 models are affected.

## Merge Order
1. Merge + tag livequery-models `v1.12.1`
2. Merge + tag this PR as `v1.42.1`
3. Bump fsc-evm `packages.yml` to fsc-utils `v1.42.1`